### PR TITLE
Fixed 404 error link to package list on pkgs.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
 		<h2>Links:</h2>
 		<ul>
 			<li>Telegram channel with news and updates: <a target="_blank" rel="noopener" href="https://t.me/s/chaotic_aur">@chaotic_aur</a> (includes a discussion group)</li>
-			<li>Package list: <a target="_blank" rel="noopener" href="https://archlinux.pkgs.org/rolling/chaotic-aur-x86_64">Pkgs.org</a></li>
+			<li>Package list: <a target="_blank" rel="noopener" href="https://archlinux.pkgs.org/rolling/chaotic-aur-x86_64/">Pkgs.org</a></li>
 			<li>Infra / toolbox source code: <a target="_blank" rel="noopener" href="https://github.com/chaotic-aur/toolbox">GitHub</a></li>
 			<li>Status page: <a target="_blank" rel="noopener" href="https://status.chaotic.cx">Status monitoring</a></li>
 			<li>Latest logs: <a target="_blank" rel="noopener" href="https://builds.garudalinux.org/repos/chaotic-aur/logs/">Logfiles</a></li>


### PR DESCRIPTION
Fixed link to pkgs.org on chaotic.cx that was returning 404 error due to a missing forward slash at end